### PR TITLE
Fix command line argument parser for --move_data

### DIFF
--- a/scOT/utils.py
+++ b/scOT/utils.py
@@ -75,7 +75,8 @@ def read_cli(parser):
     )
     parser.add_argument(
         "--move_data",
-        str=None,
+        type=str,
+        default=None,
         help="If set, moves the data to this directory and trains from there.",
     )
     return parser


### PR DESCRIPTION
The argument parser for the training script seemed to have a mistake in it, resulting in the following error:
`TypeError: _StoreAction.__init__() got an unexpected keyword argument 'str'`
This pull request fixes how `--move_data` is added.