### PR TITLE
Explicitly save model after training (to deal with bug in transformers 4.29.2)

### DIFF
--- a/scOT/train.py
+++ b/scOT/train.py
@@ -407,7 +407,8 @@ if __name__ == "__main__":
     )
 
     trainer.train(resume_from_checkpoint=params.resume_training)
-
+    trainer.save_model(train_config.output_dir)
+    
     if (RANK == 0 or RANK == -1) and params.push_to_hf_hub is not None:
         model.push_to_hub(params.push_to_hf_hub)
 


### PR DESCRIPTION
As shown in #4, models are not saved after training runs due to a bug in `transformers` 4.29.2.

This PR fixes the issue by explicitly calling `trainer.save_model` after training. Note that the training script has `load_best_model_at_end=True`, so this results in the **best** model being saved.